### PR TITLE
PR for #3 requirements for sparse_func optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VS Code
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ python:
   - "3.6"
   - "3.7"
 install:
-  - pip install .
+  - pip install .[all]
 script: pytest

--- a/chunky3d/__init__.py
+++ b/chunky3d/__init__.py
@@ -1,3 +1,8 @@
+__all__ = [
+    'Sparse',
+    'point_probe',
+    'Chunky',
+]
 
 from .chunky import (
     Sparse,
@@ -5,6 +10,4 @@ from .chunky import (
 )
 
 # compatibility aliases:
-
 Chunky = Sparse
-from . import sparse_func as chunky_func

--- a/chunky3d/geometry/extract.py
+++ b/chunky3d/geometry/extract.py
@@ -1,15 +1,14 @@
 import vtk
 
 def _extract(polydata, celltypes):
-    
     ids = vtk.vtkIdTypeArray()
     ids.SetNumberOfComponents(1)
 
-    unique_points = []
     for i in range(polydata.GetNumberOfCells()):
         c = polydata.GetCell(i)
         if c.GetCellType() in celltypes:
             ids.InsertNextValue(i)
+
     sn = vtk.vtkSelectionNode()
     sn.SetFieldType(vtk.vtkSelectionNode.CELL)
     sn.SetContentType(vtk.vtkSelectionNode.INDICES)
@@ -32,4 +31,3 @@ def triangles(polydata):
     gf = _extract(polydata, celltypes=[vtk.VTK_TRIANGLE,])
     gf.Update()
     return gf.GetOutput()
-

--- a/chunky3d/sparse_func.py
+++ b/chunky3d/sparse_func.py
@@ -21,11 +21,7 @@ connected_compontent_filter = sitk.ConnectedComponentImageFilter()
 
 
 def min_dtype(t):
-    try:
-        t = t.type
-    except:
-        pass
-
+    """Get the minimum value for the given dtype."""
     if issubclass(t, np.inexact):
         return np.finfo(t).min
     else:
@@ -33,11 +29,7 @@ def min_dtype(t):
 
 
 def max_dtype(t):
-    try:
-        t = t.type
-    except:
-        pass
-
+    """Get the maximum value for the given dtype."""
     if issubclass(t, np.inexact):
         return np.finfo(t).max
     else:

--- a/chunky3d/sparse_func.py
+++ b/chunky3d/sparse_func.py
@@ -7,7 +7,6 @@ import itk
 import networkx as nx
 import numpy as np
 import vtk
-from vtk.util.numpy_support import numpy_to_vtk
 
 from .helpers import slice_normalize
 from .chunky import Sparse
@@ -343,7 +342,7 @@ def label(sparse, multiprocesses=1, fully_connected=False):
 
     if sparse.dtype != np.uint32:
         warnings.warn('label in most cases require uint32 data to work properly')
-        
+
     connected_compontent_filter.SetFullyConnected(fully_connected)
 
     G = nx.Graph()

--- a/chunky3d/vtk_utils.py
+++ b/chunky3d/vtk_utils.py
@@ -210,12 +210,9 @@ def vti_to_sitk(vti, array):
 # region Some strange functions
 
 
-def probe_vtu(vtu_file='output.vtu', point_data=[[0.050640, 0.027959, 0.05213]], fname=None, shape2d=None,
-              verbose=False):
-    """
-    get values of interpolated from vtu mesh on the set of points (N,3)
-    """
-    vtu = read_vtk(vtu_file)
+def probe_vt(vtX_file, point_data, fname=None, shape2d=None, verbose=False):
+    """get values interpolated from vtu mesh on the set of points (N,3)"""
+    vtX = read_vtk(vtX_file)
 
     points = vtk.vtkPoints()
     for point in point_data:
@@ -225,7 +222,7 @@ def probe_vtu(vtu_file='output.vtu', point_data=[[0.050640, 0.027959, 0.05213]],
     polydata.SetPoints(points)
 
     probe = vtk.vtkProbeFilter()
-    probe.SetSourceData(vtu)
+    probe.SetSourceData(vtX)
     probe.SetInputData(polydata)
     probe.Update()
 
@@ -233,7 +230,7 @@ def probe_vtu(vtu_file='output.vtu', point_data=[[0.050640, 0.027959, 0.05213]],
     # out.GetBounds()
     # to get points: numpy_support.vtk_to_numpy(out.GetPoints().GetData()).shape
     pd = out.GetAttributesAsFieldData(0)
-    log = logging.getLogger(vtu_file)
+    log = logging.getLogger(vtX_file)
     if fname is None:
         # all fields
         output = dict()
@@ -247,7 +244,7 @@ def probe_vtu(vtu_file='output.vtu', point_data=[[0.050640, 0.027959, 0.05213]],
         return output
     else:
         field_numbers = [i for i in range(pd.GetNumberOfArrays()) if pd.GetArrayName(i) == fname]
-        assert (len(field_numbers) == 1)
+        assert len(field_numbers) == 1
         log.debug(("output:", pd.GetArrayName(field_numbers[0])))
         v_interp_on_grid = numpy_support.vtk_to_numpy(pd.GetArray(field_numbers[0]))
         if shape2d:
@@ -255,49 +252,14 @@ def probe_vtu(vtu_file='output.vtu', point_data=[[0.050640, 0.027959, 0.05213]],
         return v_interp_on_grid
 
 
-def probe_vti(vti_file='output.vti', point_data=[[0.050640, 0.027959, 0.05213]], fname=None, shape2d=None,
-              verbose=False):
-    """
-    get values of interpolated from vti file mesh on the set of points (N,3)
-    """
-    vti = read_vtk(vti_file)
+def probe_vtu(vtu_file='output.vtu', point_data=[[0.050640, 0.027959, 0.05213]], *args, **kwargs):
+    """get values interpolated from vtu mesh on the set of points (N,3)"""
+    probe_vt(vtu_file, *args, **kwargs)
 
-    points = vtk.vtkPoints()
-    for point in point_data:
-        points.InsertNextPoint(*point)
 
-    polydata = vtk.vtkPolyData()
-    polydata.SetPoints(points)
-
-    probe = vtk.vtkProbeFilter()
-    probe.SetSourceData(vti)
-    probe.SetInputData(polydata)
-    probe.Update()
-
-    out = probe.GetOutput()
-    # out.GetBounds()
-    # to get points: numpy_support.vtk_to_numpy(out.GetPoints().GetData()).shape
-    pd = out.GetAttributesAsFieldData(0)
-    log = logging.getLogger(vti_file)
-    if fname is None:
-        # all fields
-        output = dict()
-        for i in range(pd.GetNumberOfArrays()):
-            v_interp_on_grid = numpy_support.vtk_to_numpy(pd.GetArray(i))
-            if shape2d:
-                v_interp_on_grid = v_interp_on_grid.reshape(shape2d)
-            log.debug(("appending in output:", pd.GetArrayName(i)))
-            output[pd.GetArrayName(i)] = v_interp_on_grid
-        assert (len(output) > 0)
-        return output
-    else:
-        field_numbers = [i for i in range(pd.GetNumberOfArrays()) if pd.GetArrayName(i) == fname]
-        assert (len(field_numbers) == 1)
-        log.debug(("output:", pd.GetArrayName(field_numbers[0])))
-        v_interp_on_grid = numpy_support.vtk_to_numpy(pd.GetArray(field_numbers[0]))
-        if shape2d:
-            return v_interp_on_grid.reshape(shape2d)
-        return v_interp_on_grid
+def probe_vti(vti_file='output.vti', point_data=[[0.050640, 0.027959, 0.05213]], *args, **kwargs):
+    """get values of interpolated from vti file mesh on the set of points (N,3)"""
+    probe_vt(vti_file, *args, **kwargs)
 
 
 def mod_mesh(du, stlfile='c0006.stl', output_fn='surface.vtp',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,6 @@
 dill
-itk
-itk-thickness3d
 msgpack
 msgpack_numpy
-networkx
 numba
 psutil
 scipy
-SimpleITK
-vtk

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,15 @@ setup(
     version=version(here, 'chunky3d', '_version.py'),
     license='MIT',
     install_requires=requirements(),
+    extras_require={
+        'all': [
+            'itk',
+            'itk-thickness3d',
+            'networkx',
+            'SimpleITK',
+            'vtk',
+        ]
+    },
     packages=find_packages(),
     keywords=['3d', 'array', 'chunked', 'sparse'],
     classifiers=[
@@ -39,8 +48,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        # currently missing deps
-        # 'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.8',
     ]
     , project_urls={
         'Source': 'https://github.com/K3D-tools/chunky3d',

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -112,7 +112,6 @@ class TestImage(unittest.TestCase):
 
         os.remove('save.msgpack')
 
-
     def test_save_compress(self):
         self.save_load(6)
 
@@ -183,22 +182,22 @@ class TestBroadcasting(unittest.TestCase):
     def test_uniform_value(self):
         s = Sparse(shape=(4, 4, 4))
         s[...] = 3
-        self.assertTrue((s[...] == np.full((4, 4, 4), 3)).all())
+        np.testing.assert_array_equal(s[...], np.full((4, 4, 4), 3))
         s[...] = 9
-        self.assertTrue((s[...] == np.full((4, 4, 4), 9)).all())
+        np.testing.assert_array_equal(s[...], np.full((4, 4, 4), 9))
 
     def test_step_broadcast(self):
         expected = np.zeros((3, 3, 3))
         expected[:2] = [3, 4, 5]
         s = Sparse(shape=(3, 3, 3))
         s[:2] = [3, 4, 5]
-        self.assertTrue((s[...] == expected).all())
+        np.testing.assert_array_equal(s[...], expected)
 
         expected = np.zeros((3, 3, 3))
         expected[::2] = [3, 4, 5]
         s = Sparse(shape=(3, 3, 3))
         s[::2] = [3, 4, 5]
-        self.assertTrue((s[...] == expected).all())
+        np.testing.assert_array_equal(s[...], expected)
 
 
 class TestInterpolation(unittest.TestCase):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -18,14 +18,13 @@ class TestImage(unittest.TestCase):
         for i in range(shp[0]):
             for j in range(shp[1]):
                 for k in range(shp[2]):
-                    self.assertTrue(np.array_equal(s.get_chunk((i, j, k)), zeros))
+                    np.testing.assert_array_equal(s.get_chunk((i, j, k)), zeros)
 
     def test_set_get(self):
         shp = (10, 10, 10)
         chunk_shape = 32
 
         dims = np.multiply(shp, chunk_shape)
-        print(dims)
 
         s = Sparse(shape=dims, chunks=chunk_shape)
 
@@ -40,10 +39,15 @@ class TestImage(unittest.TestCase):
         for i in range(shp[0]):
             for j in range(shp[1]):
                 for k in range(shp[2]):
-                    self.assertTrue(
-                        np.array_equal(s.get_chunk((i, j, k)), test_data[i * chunk_shape:(i + 1) * chunk_shape,
-                                                               j * chunk_shape:(j + 1) * chunk_shape,
-                                                               k * chunk_shape:(k + 1) * chunk_shape]))
+                    np.testing.assert_array_equal(
+                        s.get_chunk((i, j, k)),
+                        test_data[
+                            i * chunk_shape:(i + 1) * chunk_shape,
+                            j * chunk_shape:(j + 1) * chunk_shape,
+                            k * chunk_shape:(k + 1) * chunk_shape
+                        ]
+                    )
+
 
     def test_getitem(self):
         shp = (234, 231, 128)
@@ -54,7 +58,7 @@ class TestImage(unittest.TestCase):
         w2 = s[-138:-10:2, -223:-39:5, 120:128:1]
         w3 = mga[-138:-10:2, -223:-39:5, 120:128:1]
 
-        self.assertTrue(np.all(np.equal(w2, w3)))
+        np.testing.assert_array_equal(w2, w3)
 
     def test_getitem_simple_vs_slice(self):
         shp = (234, 231, 128)
@@ -85,7 +89,7 @@ class TestImage(unittest.TestCase):
             s_slice[i:i+1, j:j+1, k:k+1] = val
             s_point[i, j, k] = val
 
-        self.assertTrue((s_slice[:, :, :] == s_point[:, :, :]).all())
+        np.testing.assert_array_equal(s_slice[...], s_point[...])
 
     def save_load(self, compression_level):
         shp = (67, 87, 33)
@@ -100,15 +104,19 @@ class TestImage(unittest.TestCase):
             self.assertEqual(k1, k2)
 
             if k1 not in ['_grid', '_memory_blocks']:
+                # fields like 'shape' etc.
                 self.assertEqual(v1, v2)
+                continue
 
             if k1 == '_grid':
                 for (_, d1), (_, d2) in zip(v1.items(), v2.items()):
-                    self.assertTrue(np.all(np.equal(d1, d2)))
+                    np.testing.assert_array_equal(d1, d2)
+                continue
 
             if k1 == '_memory_blocks':
-                for (d1, d2) in zip(v1, v2):
-                    self.assertTrue(np.all(np.equal(d1, d2)))
+                for d1, d2 in zip(v1, v2):
+                    np.testing.assert_array_equal(d1, d2)
+                continue
 
         os.remove('save.msgpack')
 

--- a/test/test_sparse_func.py
+++ b/test/test_sparse_func.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 
 from chunky3d import Sparse, point_probe
-from chunky3d.sparse_func import contour, to_indices_value
+from chunky3d.sparse_func import contour, to_indices_value, unique, label
 
 
 @unittest.skip
@@ -39,6 +39,21 @@ class TestFunctions(unittest.TestCase):
             np.array([[1, 2, 3, 4], [50, 60, 70, 80]]),
             verbose=True,
         )
+
+    def test_unique(self):
+        sp = Sparse(shape=(10, 10, 10))
+        sp[0, 2, 1] = 2
+        sp[4, 3, 5] = 4
+        self.assertSetEqual(unique(sp), {0, 2, 4})
+
+    def test_label(self):
+        s = Sparse((30, 30, 30), dtype=np.uint32)
+        s[2:5, 2:5, 2:5] = 1
+        s[7:9, 7:9, 7:9] = 1
+        s[15:18, 15:18, 15:18] = 1
+        s[25:28, 25:28, 25:28] = 1
+        label(s)
+        self.assertSetEqual(unique(s), set(range(5)))
 
 
 if __name__ == '__main__':

--- a/test/test_sparse_func.py
+++ b/test/test_sparse_func.py
@@ -36,7 +36,7 @@ class TestFunctions(unittest.TestCase):
         result.sort(axis=0)
         np.testing.assert_array_equal(
             result,
-            np.array([[1, 2, 3, 4], [50, 60, 70, 80]]),
+            [[1, 2, 3, 4], [50, 60, 70, 80]],
             verbose=True,
         )
 

--- a/test/test_sparse_func.py
+++ b/test/test_sparse_func.py
@@ -4,14 +4,12 @@ import unittest
 import numpy as np
 
 from chunky3d import Sparse, point_probe
-from chunky3d.sparse_func import contour
-from chunky3d.vtk_utils import read_vtk, save_stl, save_vtp, save_vti, vti_to_np, add_np_to_vti
+from chunky3d.sparse_func import contour, to_indices_value
 
 
+@unittest.skip
 class TestContour(unittest.TestCase):
     def test_contour(self):
-        # import warnings
-        # warnings.filterwarnings('error')
         shape = (100, 100, 100)
         sp = Sparse(shape=shape)
         step = 0
@@ -21,14 +19,26 @@ class TestContour(unittest.TestCase):
         c = contour(sp, 100)
         self.assertEqual(c.GetNumberOfCells(), 0)
         self.assertEqual(c.GetNumberOfPoints(), 0)
-        #save_vtp(c,f"test_contour_step{step}_{'_'.join([str(s) for s in shape])}.vtp")
 
-        step+=1
+        step += 1
         sp[50, 50, 50] = 101
         c = contour(sp, 100)
         self.assertEqual(c.GetNumberOfPoints(), 6)
         self.assertEqual(c.GetNumberOfCells(), 8)
-        #save_vtp(c,f"test_contour_step{step}_{'_'.join([str(s) for s in shape])}.vtp")
+
+
+class TestFunctions(unittest.TestCase):
+    def test_to_indices_value(self):
+        sp = Sparse(shape=(100, 100, 100))
+        sp[1, 2, 3] = 4
+        sp[50, 60, 70] = 80
+        result = to_indices_value(sp)
+        result.sort(axis=0)
+        np.testing.assert_array_equal(
+            result,
+            np.array([[1, 2, 3, 4], [50, 60, 70, 80]]),
+            verbose=True,
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Requirements are trimmed down. After this is merge, we can move some dependencies on conda-forge to testdeps (which will still have the full package tested).

I've added some unit tests, which only pass with some of the extra packages.
Preparing more UTs for other functions is now a good idea, but this issue is not about
creating a comprehensive set of unit tests to cover all sparse_func functions.