### PR TITLE
Added scikit-image requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ msgpack_numpy
 numba
 psutil
 scipy
+scikit-image


### PR DESCRIPTION
Since package is imported in vtk_utils.py it throws
exception for non extras installation.