### PR TITLE
cutting data by envelope bug-fix

### DIFF
--- a/chunky3d/sparse_func.py
+++ b/chunky3d/sparse_func.py
@@ -566,7 +566,7 @@ def contour(
         vti.SetSpacing(data.spacing)
         series_name = "sparse"
         add_np_to_vti(
-            vti, data[: -envelope[0], : -envelope[1], : -envelope[2]], series_name
+            vti, data[envelope[0]:-envelope[0], envelope[1]:-envelope[1], envelope[2]:-envelope[2]], series_name
         )
         vti.GetPointData().SetActiveScalars(series_name)
         contour = vtk.vtkImageMarchingCubes()


### PR DESCRIPTION
I've noticed a bug when using contour function which caused an unexpected offset of Sparse objects.

In my opinion, there is a bug in _chunk_contour_ function.
It is "slicing" data cube only on 3 faces of the cube, leaving the envelope on 3 remaining faces.

I've added code that should fix the issue. Please let me know if my reasoning is correct.