### PR TITLE
Changing thinning to use scikit-image

### DIFF
--- a/chunky3d/_version.py
+++ b/chunky3d/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 1, 9)
+version_info = (0, 1, 10)
 __version__ = ".".join(map(str, version_info))

--- a/test/test_sparse_func.py
+++ b/test/test_sparse_func.py
@@ -10,8 +10,6 @@ from chunky3d.sparse_func import (
     thinning,
     to_indices_value,
     unique,
-    _have_itk,
-    _have_itk_thickness,
     _have_nx,
     _have_sitk,
     _have_vtk,
@@ -115,11 +113,8 @@ class TestFunctions(unittest.TestCase):
         np.testing.assert_array_equal(s[2:5, 2:5, 2:5], expected)
         self.assertEqual(sf.sum(s), 3 ** 3 - 8)
 
-    @unittest.skipUnless(
-        _have_itk and _have_itk_thickness, "this test needs ITK and itk-thickness3d"
-    )
     def test_thinning(self):
-        s = Sparse((5, 5, 5), dtype=np.uint16)
+        s = Sparse((5, 5, 5), dtype=np.uint8)
         s[...] = 1
         s[2, 2] = 0
         expected_slice = np.array(


### PR DESCRIPTION
This PR contains two main changes:
1. Changed moment of itk and BinaryThinningImageFilter3D import from module loading level to "lazy" or "on demand".
2. Changed thinning to use skeletonize_3d from scikit-image instead of BinaryThinningImageFilter3D from itk-thickness3d.

The motivation behind the first change is that loading itk-thickness3d module takes a long time. I checked it on several machines and it's significant on all of them. These are just two tests on different computers:
`python -c "import time; s=time.time(); import itk; itk.BinaryThinningImageFilter3D; print(time.time()-s)"`
Laptop with Windows 10: 20.220796585083008
PC for high performance processing, with Ubuntu: 14.832442283630371

As for the second change, first of all, it enables not loading itk-thickness3d :), but also there's a huge difference in terms of speed. I prepared the following script to compare these two approaches which uses segmentation of vessels from K3D examples: https://k3d-jupyter.org/gallery/showcase/segmentation.html:

```python
import os
import time
import urllib.request as uq
import numpy as np
from skimage.morphology import skeletonize_3d
from chunky3d import Sparse
import chunky3d.sparse_func as sf

def thinning_skimage(sparse, envelope, multiprocesses=1):
    sparse.run(
        lambda data, prev: (
            (skeletonize_3d(data) > 0).astype(data.dtype),
            prev,
        ),
        envelope=envelope,
        skip_neighbours=True,
        multiprocesses=multiprocesses,
    )

def test_thinning_performance_and_compatibility():
    filename = "segmentations.npz"

    if not os.path.isfile(filename):
        uq.urlretrieve("https://k3d-jupyter.org/_downloads/db5092e1f8b484e7e43ec68ac21916bc/segmentations.npz", filename)

    data = np.load(filename)["GT"]

    sp_itk = Sparse(data.shape)
    sp_itk[()] = data
    start_itk = time.time()
    sf.thinning(sp_itk, envelope=(32,)*3)
    print("ITK thinning:", time.time() - start_itk)
    # sp_itk.save("thin_itk.sparse")

    sp_skimage = Sparse(data.shape)
    sp_skimage[()] = data
    start_skimage = time.time()
    thinning_skimage(sp_skimage, envelope=(32,)*3)
    print("skimage thinning:", time.time() - start_skimage)
    # sp_skimage.save("thin_skimage.sparse")

    print("Same results:", np.array_equal(sp_itk[()], sp_skimage[()]))


if __name__ == "__main__":
    test_thinning_performance_and_compatibility()

```
I got the following results:
```
ITK thinning: 24.03553795814514
skimage thinning: 2.584907054901123
Same results: True
```
So, seems that method with skimage is almost 10x faster and gives the same results as the itk-thickness3d method.
...and have I mentioned that it doesn't require waiting 15 s for the module to load? :)