### PR TITLE
fix for add_scalar, mul_scalar and sum for non-zero fill_value

### DIFF
--- a/chunky3d/sparse_func.py
+++ b/chunky3d/sparse_func.py
@@ -134,7 +134,7 @@ def sum(sparse, multiprocesses=1):
             prev=0,
             multiprocesses=multiprocesses,
         )
-    )
+    ) + (sparse.nchunks - sparse.nchunks_initialized) * np.prod(sparse.chunks) * sparse.fill_value
 
 
 def downsample(sparse, stride=(3, 3, 3)):
@@ -303,10 +303,12 @@ def subtract(sparse_a, sparse_b):
 
 def add_scalar(sparse_a, val, multiprocesses=1):
     sparse_a.run(lambda data, prev: (data + val, prev), multiprocesses=multiprocesses)
+    sparse_a.fill_value = sparse_a.fill_value + val
 
 
 def mul_scalar(sparse_a, val, multiprocesses=1):
     sparse_a.run(lambda data, prev: (data * val, prev), multiprocesses=multiprocesses)
+    sparse_a.fill_value = sparse_a.fill_value * val
 
 
 def any(sparse: Sparse, func=None) -> bool:

--- a/test/test_sparse_func.py
+++ b/test/test_sparse_func.py
@@ -149,6 +149,26 @@ class TestFunctions(unittest.TestCase):
         npt.assert_array_equal(sp1[:,:,:], sp_exp[:,:,:])
 
 
+    def test_add_scalar(self):
+        sp0 = Sparse(shape=(4, 4, 4), chunks=(2,2,2), fill_value=0)
+        sp0[0, 0, 0] = 1
+        sf.add_scalar(sp0, 1)
+        
+        self.assertEqual(sp0.fill_value, 1)
+        self.assertEqual(sp0[0,0,0], 2)
+        self.assertEqual(sf.sum(sp0), 4**3 + 1)
+
+    def test_mul_scalar(self):
+        sp0 = Sparse(shape=(4, 4, 4), chunks=(2,2,2), fill_value=0)
+        sp0[0, 0, 0] = 1
+        sf.add_scalar(sp0, 1)
+        sf.mul_scalar(sp0, 2)
+        
+        self.assertEqual(sp0.fill_value, 2)
+        self.assertEqual(sp0[0,0,0], 4)
+        self.assertEqual(sf.sum(sp0), 2 * (4**3 + 1))
+
+
     def test_max(self):
         sp = Sparse(shape=(10, 10, 10))
         sp[0, 2, 1] = 2
@@ -189,17 +209,6 @@ class TestFunctions(unittest.TestCase):
         sp = Sparse(shape=(10, 10, 10), chunks=4)
         result = where(sp, lambda x: x > 1)
         np.testing.assert_array_equal(result, np.empty((3, 0), dtype=np.intp))
-
-    def test_mul_scalar(self):
-        sp = Sparse(shape=(4, 4, 4), chunks=2)
-        sp[0, 0, 0] = 1
-        sp[3, 3, 3] = 2
-
-        mul_scalar(sp, 3)
-
-        self.assertEqual(sp[0, 0, 0], 3)
-        self.assertEqual(sp[3, 3, 3], 6)
-        self.assertEqual(sp[1, 1, 1], 0)
 
     def test_any_no_func(self):
         sp = Sparse(shape=(4, 4, 4), chunks=2)


### PR DESCRIPTION
This fixes 
- add_scalar
- mul_scalar
- sum
from sparse_func to properly implement operations that use or yield a non-zero fill_value