### PR TITLE
sf.label will keep fill_value intact

### DIFF
--- a/chunky3d/sparse_func.py
+++ b/chunky3d/sparse_func.py
@@ -560,23 +560,18 @@ def label(sparse, multiprocesses=1, fully_connected=False):
     for idx, k in enumerate(set(range(1, component_sum + 1)) - val_map.keys()):
         val_map[k] = idx + len(cutted_G) + 1
 
-    add_scalar(sparse, component_sum + 1)
     component_index = 1
 
     for k, component_count in zip(
         sorted(sparse._grid.keys()), component_count_per_chunk
     ):
-        chunk = sparse.get_chunk(k)
+        chunk = sparse.get_chunk(k).copy()
 
         for _ in range(component_count):
             if component_index in val_map:
-                chunk[chunk == (component_index + component_sum + 1)] = val_map[
-                    component_index
-                ]
+                chunk[chunk == component_index] = val_map[component_index]
 
             component_index += 1
-
-        chunk[chunk > component_sum] -= component_sum + 1
 
         sparse.set_chunk(k, chunk)
 

--- a/test/test_sparse_func.py
+++ b/test/test_sparse_func.py
@@ -241,13 +241,21 @@ class TestFunctions(unittest.TestCase):
         _have_sitk and _have_nx, "this test needs SimpleITK and NetworkX"
     )
     def test_label(self):
-        s = Sparse((30, 30, 30), dtype=np.uint32)
+        s = Sparse((30, 30, 30), chunks=2, dtype=np.uint32)
         s[2:5, 2:5, 2:5] = 1
         s[7:9, 7:9, 7:9] = 1
         s[15:18, 15:18, 15:18] = 1
         s[25:28, 25:28, 25:28] = 1
         label(s)
+        
         self.assertSetEqual(unique(s), set(range(5)))
+        de_facto_indices = [s[2,2,2], s[7,7,7], s[15,15,15], s[25,25,25]]
+        self.assertSetEqual(set(de_facto_indices), set(range(1,5)))
+        np.testing.assert_array_equal(s[2:5, 2:5, 2:5], de_facto_indices[0])
+        np.testing.assert_array_equal(s[7:9, 7:9, 7:9], de_facto_indices[1])
+        np.testing.assert_array_equal(s[15:18, 15:18, 15:18], de_facto_indices[2])
+        np.testing.assert_array_equal(s[25:28, 25:28, 25:28], de_facto_indices[3])
+        self.assertEqual(s.fill_value, 0)
 
     @unittest.skipUnless(_have_sitk, "this test needs SimpleITK")
     def test_dilate(self):


### PR DESCRIPTION
So far sf.label alters sparse's `fill_value` for internal purposes and never fixes it back as it did `add_scalar(sparse, component_sum + 1)`. 
This PR modifies `sf.label` by simplifying it so that it doesn't need to alter the original sparse fill_value.
