### PR TITLE
Update grid

### DIFF
--- a/chunky3d/chunky.py
+++ b/chunky3d/chunky.py
@@ -571,6 +571,26 @@ class Sparse:
         else:
             self._grid[idx][:] = d
 
+    def _update_grid(self):
+        """In case the underlying `_memory_blocks` and `_grid_mask` change, this method updates the `_grid`."""
+        chunks = self.chunks
+        grid = {}
+        for i, j, k in np.argwhere(self.grid_mask != Sparse.EMPTY_GRID_VALUE):
+            idx = self._grid_mask[i, j, k]
+            envelope = 0
+            grid[(i, j, k)] = self._make_chunk(
+                self.dense_data[
+                    envelope
+                    + idx * (chunks[0] + 2 * envelope) : envelope
+                    + idx * (chunks[0] + 2 * envelope)
+                    + chunks[0],
+                    envelope : envelope + chunks[1],
+                    envelope : envelope + chunks[2],
+                ],
+                idx,
+            )
+        self._grid = grid
+
     def set_chunk(self, idx, val):
         """
         Set chunk in the grid.

--- a/chunky3d/chunky.py
+++ b/chunky3d/chunky.py
@@ -503,8 +503,8 @@ class Sparse:
         else:
             self._grid_mask.fill(Sparse.EMPTY_GRID_VALUE)
 
-        self._grid_mask[tuple(np.array(sorted(self._grid.keys())).T)] = (
-            np.arange(self.nchunks_initialized)
+        self._grid_mask[tuple(np.array(sorted(self._grid.keys())).T)] = np.arange(
+            self.nchunks_initialized
         )
 
     def get_chunk(self, idx, dtype=None):
@@ -571,7 +571,7 @@ class Sparse:
         else:
             self._grid[idx][:] = d
 
-    def _update_grid(self):
+    def _update_grid(self, envelope: int = 0):
         """In case the underlying `_memory_blocks` and `_grid_mask` change, this method updates the `_grid`."""
         chunks = self.chunks
         grid = {}
@@ -589,6 +589,7 @@ class Sparse:
                 ],
                 idx,
             )
+
         self._grid = grid
 
     def set_chunk(self, idx, val):

--- a/chunky3d/chunky.py
+++ b/chunky3d/chunky.py
@@ -32,7 +32,7 @@ def fast_get(
 
     idx = grid_mask[bi, bj, bk]
 
-    if idx != 0xFFFFFFFF:
+    if idx != Sparse.EMPTY_GRID_VALUE:
         return dense_data[
             envelope + idx * (chunks[0] + 2 * envelope) + li,
             envelope + lj,
@@ -211,6 +211,8 @@ class Sparse:
         set: insert dense submatrix into structure
         get_k3d_voxels_group_dict: get chunks as list of dict for use in K3D voxels group
     """
+
+    EMPTY_GRID_VALUE = 0xFFFFFFFF
 
     def __init__(
         self,
@@ -417,7 +419,7 @@ class Sparse:
     def fill_value(self):
         """ A value used for uninitialized (empty) portions of the array. """
         return self._default_value
-    
+
     @fill_value.setter
     def fill_value(self, fill_value):
         self._default_value = fill_value
@@ -495,12 +497,14 @@ class Sparse:
             type(self._grid_mask) is not np.ndarray
             or self._grid_mask.shape != self._block_shape
         ):
-            self._grid_mask = np.full(self._block_shape, 0xFFFFFFFF, dtype=np.uint32)
+            self._grid_mask = np.full(
+                self._block_shape, Sparse.EMPTY_GRID_VALUE, dtype=np.uint32
+            )
         else:
-            self._grid_mask.fill(0xFFFFFFFF)
+            self._grid_mask.fill(Sparse.EMPTY_GRID_VALUE)
 
-        self._grid_mask[tuple(np.array(sorted(self._grid.keys())).T)] = np.arange(
-            self.nchunks_initialized
+        self._grid_mask[tuple(np.array(sorted(self._grid.keys())).T)] = (
+            np.arange(self.nchunks_initialized)
         )
 
     def get_chunk(self, idx, dtype=None):

--- a/chunky3d/chunky.py
+++ b/chunky3d/chunky.py
@@ -571,8 +571,11 @@ class Sparse:
         else:
             self._grid[idx][:] = d
 
-    def _update_grid(self, envelope: int = 0):
-        """In case the underlying `_memory_blocks` and `_grid_mask` change, this method updates the `_grid`."""
+    def update_grid(self, envelope: int = 0):
+        """In case the underlying `_memory_blocks` and `_grid_mask` change, this method updates the `_grid`.
+
+        WARNING: the underlying `dense_data` has to be continuous, use at your own discretion!
+        """
         chunks = self.chunks
         grid = {}
         for i, j, k in np.argwhere(self.grid_mask != Sparse.EMPTY_GRID_VALUE):


### PR DESCRIPTION
In some cases (e.g. use of [np.memmap](https://numpy.org/doc/stable/reference/generated/numpy.memmap.html)) it is time-wise advantageous to swap underlying dense data by accessing private `_memory_blocks` and `_grid_mask`. In such case `_grid` keys remain out of date. Private method in this PR allows for `_grid` regeneration.